### PR TITLE
!untracked: Use sum instead of Sum

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  r-packages: displayr/r-packages@dev:09f6d99294ffdb0d736ea0088447eb04919b8c22
+  r-packages: displayr/r-packages@dev:alpha
 parameters:
   trigger-message:
     type: string

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: flipTables
 Type: Package
 Title: Package for handling tables and related objects
-Version: 2.8.6
+Version: 2.8.7
 Author: Displayr <opensource@displayr.com>
 Maintainer: Displayr <opensource@displayr.com>
 Description: Package for handling tables and related objects.

--- a/R/tidytools.R
+++ b/R/tidytools.R
@@ -198,7 +198,7 @@ SelectEntry <- function(x, row, column = NULL, return.single.value = FALSE,
             is.pct <- TRUE
     }
     if (return.single.value && is.numeric(res))
-        res <- Sum(res)
+        res <- if (all(is.na(res))) NA else sum(res, na.rm = TRUE)
     res <- unlist(res)
     if (is.pct)
     {

--- a/tests/testthat/test-tidytools.R
+++ b/tests/testthat/test-tidytools.R
@@ -721,3 +721,25 @@ test_that("DS-3886: Conversion to 3d table", {
     output.attributes <- output.attributes[names(original.attributes)]
     expect_equal(output.attributes, original.attributes)
 })
+
+test_that("Resolve issue with summing QTable", {
+    assign("productName", "Q", envir = .GlobalEnv)
+    test.case <- structure(
+        array(1:30, 
+              dim = c(3,5,2),
+              dimnames = list(LETTERS[1:3],
+                              c(letters[1:5]),
+                              c("Stat 1", "Stat 2"))
+            ), 
+        class = c("array", "QTable"),
+        questions = c("Q1", "Q2"),
+        questiontypes = c("Pick One", "Pick One")
+    )
+    expect_warning(res <- SelectEntry(test.case, "A", "a", 
+                             return.single.value = TRUE,
+                             use.statistic.attribute = TRUE),
+                   "Only the first statistic")
+    expect_equal(res, 
+                 1)
+    remove("productName", envir = .GlobalEnv)
+})


### PR DESCRIPTION
When running in Q (where QTable subscripting is disabled and base subscripting is used) the code in selectEntry, which uses the verbs version of Sum, could get an error because Sum can only accept a 3+ dimensional array if the array is also a QTable.