### PR TITLE
Revert "DDS-1241: Keep class of QTables in TidyTabularData (#33)"

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: flipTables
 Type: Package
 Title: Package for handling tables and related objects
-Version: 2.8.8
+Version: 2.8.7
 Author: Displayr <opensource@displayr.com>
 Maintainer: Displayr <opensource@displayr.com>
 Description: Package for handling tables and related objects.

--- a/R/astidytabulardata.R
+++ b/R/astidytabulardata.R
@@ -91,7 +91,7 @@ AsTidyTabularData <- function(x, ...)
         x <- AsNumeric(x)
     else if (length(dim(x)) == 1L)
         class(x) <- "numeric"
-    else if (!is.data.frame(x) && !IsQTable(x))
+    else if (!is.data.frame(x))
         class(x) <- "matrix"
     x
 }

--- a/R/tidytabulardata.R
+++ b/R/tidytabulardata.R
@@ -82,7 +82,7 @@ TidyTabularData <- function(
 
     if (is.null(dim(x)) || n.dim == 1L)
         class(x) <- "numeric"
-    else if (!is.data.frame(x) && !IsQTable(x))
+    else if (!is.data.frame(x))
         class(x) <- "matrix"
     x
 }


### PR DESCRIPTION
This reverts commit f7fbcb43c85199bc7c18389406b74dd9f9a34c64.

Causes an issue with CorrespondenceAnalysis

```
y <- array(runif(12), dim = 3:4, dimnames = list(letters[1:3], LETTERS[1:4]))
class(y) <- c("QTable", class(y))
attr(y, "statistic") <- "%"
attr(y, "row.column.names") <- c("Rows", "Columns")
flipDimensionReduction::CorrespondenceAnalysis(y)
```