### PR TITLE
DDS-1241: Keep QTable class

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: flipTables
 Type: Package
 Title: Package for handling tables and related objects
-Version: 2.8.7
+Version: 2.8.8
 Author: Displayr <opensource@displayr.com>
 Maintainer: Displayr <opensource@displayr.com>
 Description: Package for handling tables and related objects.

--- a/R/astidytabulardata.R
+++ b/R/astidytabulardata.R
@@ -91,7 +91,7 @@ AsTidyTabularData <- function(x, ...)
         x <- AsNumeric(x)
     else if (length(dim(x)) == 1L)
         class(x) <- "numeric"
-    else if (!is.data.frame(x))
+    else if (!is.data.frame(x) && !IsQTable(x))
         class(x) <- "matrix"
     x
 }

--- a/R/tidytabulardata.R
+++ b/R/tidytabulardata.R
@@ -82,7 +82,7 @@ TidyTabularData <- function(
 
     if (is.null(dim(x)) || n.dim == 1L)
         class(x) <- "numeric"
-    else if (!is.data.frame(x))
+    else if (!is.data.frame(x) && !IsQTable(x))
         class(x) <- "matrix"
     x
 }


### PR DESCRIPTION
Revert "Revert "DDS-1241: Keep class of QTables in TidyTabularData (#33)" (#34)"

This reapplies changes for DDS-1241 (fixes have been applied in other repos)