### PR TITLE
DPI-2939 Package flipTables in nix

### DIFF
--- a/package.nix
+++ b/package.nix
@@ -1,0 +1,18 @@
+{ pkgs ? import <nixpkgs> {}, displayrUtils }:
+
+pkgs.rPackages.buildRPackage {
+  name = "flipTables";
+  version = displayrUtils.extractRVersion (builtins.readFile ./DESCRIPTION); 
+  src = ./.;
+  description = ''Package for handling tables and related objects.'';
+  propagatedBuildInputs = with pkgs.rPackages; [ 
+    stringr
+    ca
+    flipTransformations
+    verbs
+    stringi
+    lubridate
+    flipTime
+    flipU
+  ];
+}


### PR DESCRIPTION
As part of the R Server CI/CD uplift, this task is to package flipTables in Nix to make R server CI/CD more reliable and reproducible. To build it, see https://github.com/Displayr/NixR