### PR TITLE
RS-18683: Keep statistic attribute

### DIFF
--- a/R/tidytabulardata.R
+++ b/R/tidytabulardata.R
@@ -68,6 +68,7 @@ TidyTabularData <- function(
     statistic.attribute <- attr(x, "statistic")
     if (!is.data.frame(x))
         x <- setDimNames(x)
+    cat("line 71: statistic:", attr(x, "statistic"), "\n")
 
     n.dim <- length(dim(x))
     ## Handle transpose
@@ -75,18 +76,22 @@ TidyTabularData <- function(
     ##   for flipDimensionReduction::CorrespondenceAnalysis !!
     if (transpose)
         x <- if (n.dim <= 2) t(x) else aperm(x, c(2, 1, 3))
+    cat("line 79: statistic:", attr(x, "statistic"), "\n")
 
     x <- RemoveRowsAndOrColumns(x, row.names.to.remove, col.names.to.remove,
                                 split)
+    cat("line 83: statistic:", attr(x, "statistic"), "\n")
     if (hide.empty.rows.and.columns)
         x <- HideEmptyRowsAndColumns(x)
 
+    cat("line 87: statistic:", attr(x, "statistic"), "\n")
     if (!is.null(statistic.attribute))
         attr(x, "statistic") <- statistic.attribute
     if (is.null(dim(x)) || n.dim == 1L)
         class(x) <- "numeric"
     else if (!is.data.frame(x) && !IsQTable(x))
         class(x) <- "matrix"
+    cat("line 94: statistic:", attr(x, "statistic"), "\n")
     x
 }
 

--- a/R/tidytabulardata.R
+++ b/R/tidytabulardata.R
@@ -65,6 +65,7 @@ TidyTabularData <- function(
     if (!is.numeric(x) || !(is.null(dim(x)) || length(dim(x)) == 2L) || IsQTable(x))
         x <- AsTidyTabularData(x, ...)
 
+    statistic.attribute <- attr(x, "statistic")
     if (!is.data.frame(x))
         x <- setDimNames(x)
 
@@ -80,6 +81,8 @@ TidyTabularData <- function(
     if (hide.empty.rows.and.columns)
         x <- HideEmptyRowsAndColumns(x)
 
+    if (!is.null(statistic.attribute))
+        attr(x, "statistic") <- statistic.attribute
     if (is.null(dim(x)) || n.dim == 1L)
         class(x) <- "numeric"
     else if (!is.data.frame(x) && !IsQTable(x))

--- a/R/tidytabulardata.R
+++ b/R/tidytabulardata.R
@@ -68,7 +68,6 @@ TidyTabularData <- function(
     statistic.attribute <- attr(x, "statistic")
     if (!is.data.frame(x))
         x <- setDimNames(x)
-    cat("line 71: statistic:", attr(x, "statistic"), "\n")
 
     n.dim <- length(dim(x))
     ## Handle transpose
@@ -76,22 +75,22 @@ TidyTabularData <- function(
     ##   for flipDimensionReduction::CorrespondenceAnalysis !!
     if (transpose)
         x <- if (n.dim <= 2) t(x) else aperm(x, c(2, 1, 3))
-    cat("line 79: statistic:", attr(x, "statistic"), "\n")
 
     x <- RemoveRowsAndOrColumns(x, row.names.to.remove, col.names.to.remove,
                                 split)
-    cat("line 83: statistic:", attr(x, "statistic"), "\n")
     if (hide.empty.rows.and.columns)
         x <- HideEmptyRowsAndColumns(x)
 
-    cat("line 87: statistic:", attr(x, "statistic"), "\n")
+    # This line is actually only needed for old outputs in Q
+    # In those cases HideEmptyRowsAndColumns calls the subscript
+    # operator which drops all attributes
     if (!is.null(statistic.attribute))
         attr(x, "statistic") <- statistic.attribute
+
     if (is.null(dim(x)) || n.dim == 1L)
         class(x) <- "numeric"
     else if (!is.data.frame(x) && !IsQTable(x))
         class(x) <- "matrix"
-    cat("line 94: statistic:", attr(x, "statistic"), "\n")
     x
 }
 

--- a/R/tidytabulardata.R
+++ b/R/tidytabulardata.R
@@ -81,9 +81,11 @@ TidyTabularData <- function(
     if (hide.empty.rows.and.columns)
         x <- HideEmptyRowsAndColumns(x)
 
-    # This line is actually only needed for old outputs in Q
-    # In those cases HideEmptyRowsAndColumns calls the subscript
-    # operator which drops all attributes
+    # This is only needed for outputs in Q
+    # This is because RemoveRowsAndOrColumns and
+    # HideEmptyRowsAndColumns call copyAttributesIfNotQTable
+    # However by default verbs has AllowQTableSubscripting
+    # set to false in Q
     if (!is.null(statistic.attribute))
         attr(x, "statistic") <- statistic.attribute
 


### PR DESCRIPTION
This change is needed to fix some DimensionReduction Standard R diffs. I actually don't understand why it didn't diff before, but I have made the change minimal (only copy the statistic attribute instead of all attributes), so it shouldn't cause any problems even if it is redundant.